### PR TITLE
windowsのキー入力の改善

### DIFF
--- a/core/notifier_windows.py
+++ b/core/notifier_windows.py
@@ -89,7 +89,7 @@ class WindowsLEDNotifier(AbstractKeyboardLEDNotifier):
             handle = kernel32.CreateFileW(
                 path,
                 _GENERIC_WRITE,  # READ権限を要求するとSharing Violationになることが多い
-                0,  # 排他アクセスのため _FILE_SHARE_READ | _FILE_SHARE_WRITE を 0 に変更
+                _FILE_SHARE_READ | _FILE_SHARE_WRITE,  # 共有アクセスを許可してキーボードフックと共存させる
                 None,
                 _OPEN_EXISTING,
                 _FILE_ATTRIBUTE_NORMAL,

--- a/utils/key_listener.py
+++ b/utils/key_listener.py
@@ -79,6 +79,8 @@ class KeyListener:
         for k in self._pressed:
             if _IS_MAC and hasattr(k, "vk") and k.vk == self._MAC_ALPHA_VK.get(char):
                 return True
+            if not _IS_MAC and hasattr(k, "vk") and k.vk == ord(char.upper()):
+                return True
             if hasattr(k, "char") and k.char and k.char.lower() == char:
                 return True
         return False
@@ -88,6 +90,9 @@ class KeyListener:
         for k in self._pressed:
             # vk ベースで判定（修飾キーによる char 変換を無視できる）
             if _IS_MAC and hasattr(k, "vk") and k.vk == self._MAC_NUM_VK.get(n):
+                return True
+            # Windows/Linux: vk で判定
+            if not _IS_MAC and hasattr(k, "vk") and k.vk == ord(str(n)):
                 return True
             # Windows/Linux: char で判定
             if hasattr(k, "char") and k.char == str(n):


### PR DESCRIPTION
## 行った変更の説明

- コマンドの入力を仮想キーとして受け付けていなかったので直した(macosは既に実装されていた)
